### PR TITLE
Add a number of checks to the builder

### DIFF
--- a/functions_framework_builder/lib/builder.dart
+++ b/functions_framework_builder/lib/builder.dart
@@ -46,7 +46,13 @@ class _FunctionsFrameworkBuilder implements Builder {
       for (var annotatedElement in reader.annotatedWithExact(_checker)) {
         // TODO: validate that annotatedElement is "shape" of a shelf handler
         final target = annotatedElement.annotation.read('target').stringValue;
-        // TODO: validate target is a valid name, and not a duplicate!
+
+        if (files.any((element) => element.target == target)) {
+          throw InvalidGenerationSourceError(
+            'A function has already been annotated with target "$target".',
+            element: annotatedElement.element,
+          );
+        }
 
         libs.putIfAbsent(input.uri, () => _prefixFromIndex(libs.length));
 

--- a/functions_framework_builder/lib/builder.dart
+++ b/functions_framework_builder/lib/builder.dart
@@ -18,6 +18,8 @@ import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
 import 'package:source_gen/source_gen.dart';
 
+import 'src/utils.dart';
+
 Builder functionsFrameworkBuilder([BuilderOptions options]) =>
     const _FunctionsFrameworkBuilder();
 
@@ -44,7 +46,7 @@ class _FunctionsFrameworkBuilder implements Builder {
 
       final reader = LibraryReader(element);
       for (var annotatedElement in reader.annotatedWithExact(_checker)) {
-        // TODO: validate that annotatedElement is "shape" of a shelf handler
+        validateHandlerShape(annotatedElement.element);
         final target = annotatedElement.annotation.read('target').stringValue;
 
         if (files.any((element) => element.target == target)) {

--- a/functions_framework_builder/lib/src/utils.dart
+++ b/functions_framework_builder/lib/src/utils.dart
@@ -1,0 +1,14 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:source_gen/source_gen.dart';
+
+void validateHandlerShape(Element element) {
+  if (element is! FunctionElement) {
+    throw InvalidGenerationSourceError(
+      'Only top-level functions are supported.',
+      element: element,
+    );
+  }
+
+  // TODO: validate that annotatedElement is "shape" of a shelf handler
+  // GoogleCloudPlatform/functions-framework-dart#21
+}

--- a/functions_framework_builder/lib/src/utils.dart
+++ b/functions_framework_builder/lib/src/utils.dart
@@ -1,4 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:meta/meta.dart';
+import 'package:shelf/shelf.dart';
 import 'package:source_gen/source_gen.dart';
 
 void validateHandlerShape(Element element) {
@@ -9,6 +12,49 @@ void validateHandlerShape(Element element) {
     );
   }
 
-  // TODO: validate that annotatedElement is "shape" of a shelf handler
-  // GoogleCloudPlatform/functions-framework-dart#21
+  final func = element as FunctionElement;
+
+  @alwaysThrows
+  void notCompatible() => throw InvalidGenerationSourceError(
+        'Not compatible with package:shelf handler "$_handlerShape"',
+        element: element,
+      );
+
+  if (func.parameters.isEmpty) {
+    notCompatible();
+  }
+
+  final firstParam = func.parameters.first;
+  if (!firstParam.isPositional) {
+    notCompatible();
+  }
+
+  if (func.parameters.skip(1).any((element) => element.isRequiredPositional)) {
+    notCompatible();
+  }
+
+  if (!_requestChecker.isExactlyType(firstParam.type)) {
+    notCompatible();
+  }
+
+  final returnType = func.returnType;
+
+  if (_responseChecker.isAssignableFromType(returnType)) {
+    return;
+  }
+
+  if (returnType.isDartAsyncFuture || returnType.isDartAsyncFutureOr) {
+    final interface = returnType as InterfaceType;
+
+    if (_responseChecker.isAssignableFromType(interface.typeArguments.single)) {
+      return;
+    }
+  }
+
+  notCompatible();
 }
+
+const _handlerShape = 'FutureOr<Response> Function(Request request)';
+
+const _requestChecker = TypeChecker.fromRuntime(Request);
+const _responseChecker = TypeChecker.fromRuntime(Response);

--- a/functions_framework_builder/pubspec.yaml
+++ b/functions_framework_builder/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   build_config: ^0.4.3
   functions_framework: ^0.1.0
   glob: ^1.2.0
+  meta: ^1.2.4
   path: ^1.7.0
+  shelf: ^0.7.9
   source_gen: ^0.9.8
 
 dev_dependencies:

--- a/functions_framework_builder/pubspec.yaml
+++ b/functions_framework_builder/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
+  analyzer: ^0.40.6
   build: ^1.3.0
   # Because this package has a build.yaml file
   build_config: ^0.4.3

--- a/functions_framework_builder/test/builder_test.dart
+++ b/functions_framework_builder/test/builder_test.dart
@@ -100,27 +100,27 @@ package:$_pkgName/test_lib.dart:8:10
   group('invalid function shapes are not allowed', () {
     final onlyFunctionMatcher =
         startsWith('Only top-level functions are supported.');
-    final notCompaitbleMatcher =
+    final notCompatibleMatcher =
         startsWith('Not compatible with package:shelf handler');
     final invalidShapes = {
       'class AClass{}': onlyFunctionMatcher,
       'int field = 5;': onlyFunctionMatcher,
       'int get getter => 5;': onlyFunctionMatcher,
       // Not enough params
-      'Responose handleGet() => null;': notCompaitbleMatcher,
+      'Response handleGet() => null;': notCompatibleMatcher,
       // First param is not positional
-      'Responose handleGet({Request reques}) => null;': notCompaitbleMatcher,
+      'Response handleGet({Request reques}) => null;': notCompatibleMatcher,
       // Too many required params
-      'Responose handleGet(Request request, int other) => null;':
-          notCompaitbleMatcher,
+      'Response handleGet(Request request, int other) => null;':
+          notCompatibleMatcher,
       // Param is wrong type
-      'Responose handleGet(int request) => null;': notCompaitbleMatcher,
+      'Response handleGet(int request) => null;': notCompatibleMatcher,
       // Return type is wrong
-      'int handleGet(Request request) => null;': notCompaitbleMatcher,
+      'int handleGet(Request request) => null;': notCompatibleMatcher,
       // Return type is wrong
-      'Future<int> handleGet(Request request) => null;': notCompaitbleMatcher,
+      'Future<int> handleGet(Request request) => null;': notCompatibleMatcher,
       // Return type is wrong
-      'FutureOr<int> handleGet(Request request) => null;': notCompaitbleMatcher,
+      'FutureOr<int> handleGet(Request request) => null;': notCompatibleMatcher,
     };
 
     for (var shape in invalidShapes.entries) {

--- a/functions_framework_builder/test/builder_test.dart
+++ b/functions_framework_builder/test/builder_test.dart
@@ -64,6 +64,8 @@ const _functions = <String, Handler>{
   'sync': prefix00.handleGet,
   'async': prefix00.handleGet2,
   'futureOr': prefix00.handleGet3,
+  'extra params': prefix00.handleGet4,
+  'optional positional': prefix00.handleGet5,
 };
 ''',
     );

--- a/functions_framework_builder/test/builder_test.dart
+++ b/functions_framework_builder/test/builder_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:build_test/build_test.dart';
 import 'package:functions_framework_builder/builder.dart';
 import 'package:source_gen/source_gen.dart';
@@ -46,6 +48,21 @@ Response handleGet(Request request) => Response.ok('Hello, World!');
 $_outputHeader
 const _functions = <String, Handler>{
   'some function': prefix00.handleGet,
+};
+''',
+    );
+  });
+
+  test('All valid function shapes are supported', () async {
+    final file = File('test/test_examples/all_valid_shapes.dart');
+    await _generateTest(
+      file.readAsStringSync(),
+      '''
+$_outputHeader
+const _functions = <String, Handler>{
+  'sync': prefix00.handleGet,
+  'async': prefix00.handleGet2,
+  'futureOr': prefix00.handleGet3,
 };
 ''',
     );

--- a/functions_framework_builder/test/test_examples/all_valid_shapes.dart
+++ b/functions_framework_builder/test/test_examples/all_valid_shapes.dart
@@ -8,11 +8,16 @@ import 'package:functions_framework/functions_framework.dart';
 import 'package:shelf/shelf.dart';
 
 @CloudFunction('sync')
-Response handleGet(Request request) => Response.ok('Hello, World!');
+Response handleGet(Request request) => throw UnimplementedError();
 
 @CloudFunction('async')
-Future<Response> handleGet2(Request request) async =>
-    Response.ok('Hello, World!');
+Future<Response> handleGet2(Request request) => throw UnimplementedError();
 
 @CloudFunction('futureOr')
-FutureOr<Response> handleGet3(Request request) => Response.ok('Hello, World!');
+FutureOr<Response> handleGet3(Request request) => throw UnimplementedError();
+
+@CloudFunction('extra params')
+Response handleGet4(Request request, [int other]) => throw UnimplementedError();
+
+@CloudFunction('optional positional')
+Response handleGet5([Request request, int other]) => throw UnimplementedError();

--- a/functions_framework_builder/test/test_examples/all_valid_shapes.dart
+++ b/functions_framework_builder/test/test_examples/all_valid_shapes.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2020, the Dart project authors.
+// Please see the AUTHORS file or details. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:functions_framework/functions_framework.dart';
+import 'package:shelf/shelf.dart';
+
+@CloudFunction('sync')
+Response handleGet(Request request) => Response.ok('Hello, World!');
+
+@CloudFunction('async')
+Future<Response> handleGet2(Request request) async =>
+    Response.ok('Hello, World!');
+
+@CloudFunction('futureOr')
+FutureOr<Response> handleGet3(Request request) => Response.ok('Hello, World!');

--- a/functions_framework_builder/test/test_examples/all_valid_shapes.dart
+++ b/functions_framework_builder/test/test_examples/all_valid_shapes.dart
@@ -21,3 +21,20 @@ Response handleGet4(Request request, [int other]) => throw UnimplementedError();
 
 @CloudFunction('optional positional')
 Response handleGet5([Request request, int other]) => throw UnimplementedError();
+
+// TODO: these should be fine, too – but more work is involoved
+//@CloudFunction('more general param type')
+Response handleGet6(Object request) => throw UnimplementedError();
+
+//@CloudFunction('more specific return type')
+_MyResponse handleGet7(Object request) => throw UnimplementedError();
+
+//@CloudFunction('more specific return type - Future')
+Future<_MyResponse> handleGet8(Object request) => throw UnimplementedError();
+
+//@CloudFunction('more specific return type - FutureOr')
+FutureOr<_MyResponse> handleGet9(Object request) => throw UnimplementedError();
+
+abstract class _MyResponse extends Response {
+  _MyResponse(int statusCode) : super(statusCode);
+}


### PR DESCRIPTION
- Validate that adding a `target` to @CloudFunction parses
- Make sure only one function has a given `target`
- Test that all valid function shapes are supported
- Validate that annotated members are functions with the right parameters and return type.
