### PR TITLE
Update `CloudFunction` so target is now an option-named parameter

### DIFF
--- a/functions_framework/CHANGELOG.md
+++ b/functions_framework/CHANGELOG.md
@@ -1,5 +1,8 @@
-# 0.1.1-dev
+# 0.2.0-dev
 
+- **BREAKING** `CloudFunction` constructor paramaters `target` is now named and
+  optional. If not specified, it defaults to the name of the annotated function.
+  (Previously, it defaulted to the string `'function'`.)
 - Detect if running on Google Cloud and generate logs appropriately.
 - Improved the error messages and exit codes for failures.
 - Correctly respond with `404` with requests for `robots.txt` and `favicon.ico`.

--- a/functions_framework/lib/functions_framework.dart
+++ b/functions_framework/lib/functions_framework.dart
@@ -3,10 +3,18 @@
 // governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'package:meta/meta_meta.dart';
+import 'package:shelf/shelf.dart';
 
+/// Use as an annotation on [Function]s that will be exposed as endpoints.
+///
+/// Can only be used on public, top-level functions that are compatible with
+/// [Handler] from `package:shelf`.
 @Target({TargetKind.function})
 class CloudFunction {
+  /// The name used to register the function in the function framework.
+  ///
+  /// If `null`, the name of the [Function] is used.
   final String target;
 
-  const CloudFunction([this.target = 'function']);
+  const CloudFunction({this.target});
 }

--- a/functions_framework/pubspec.yaml
+++ b/functions_framework/pubspec.yaml
@@ -1,5 +1,5 @@
 name: functions_framework
-version: 0.1.1-dev
+version: 0.2.0-dev
 description: >-
   FaaS (Function as a service) framework for writing portable Dart functions
 repository: https://github.com/GoogleCloudPlatform/functions-framework-dart

--- a/functions_framework_builder/test/test_examples/all_valid_shapes.dart
+++ b/functions_framework_builder/test/test_examples/all_valid_shapes.dart
@@ -7,33 +7,36 @@ import 'dart:async';
 import 'package:functions_framework/functions_framework.dart';
 import 'package:shelf/shelf.dart';
 
-@CloudFunction('sync')
-Response handleGet(Request request) => throw UnimplementedError();
+@CloudFunction()
+Response syncFunction(Request request) => throw UnimplementedError();
 
-@CloudFunction('async')
-Future<Response> handleGet2(Request request) => throw UnimplementedError();
+@CloudFunction()
+Future<Response> asyncFunction(Request request) => throw UnimplementedError();
 
-@CloudFunction('futureOr')
-FutureOr<Response> handleGet3(Request request) => throw UnimplementedError();
+@CloudFunction()
+FutureOr<Response> futureOrFunction(Request request) =>
+    throw UnimplementedError();
 
-@CloudFunction('extra params')
-Response handleGet4(Request request, [int other]) => throw UnimplementedError();
+@CloudFunction()
+Response extraParam(Request request, [int other]) => throw UnimplementedError();
 
-@CloudFunction('optional positional')
-Response handleGet5([Request request, int other]) => throw UnimplementedError();
+@CloudFunction()
+Response optionalParam([Request request, int other]) =>
+    throw UnimplementedError();
 
-// TODO: these should be fine, too – but more work is involoved
-//@CloudFunction('more general param type')
-Response handleGet6(Object request) => throw UnimplementedError();
+@CloudFunction()
+Response objectParam(Object request) => throw UnimplementedError();
 
-//@CloudFunction('more specific return type')
-_MyResponse handleGet7(Object request) => throw UnimplementedError();
+@CloudFunction()
+_MyResponse customResponse(Object request) => throw UnimplementedError();
 
-//@CloudFunction('more specific return type - Future')
-Future<_MyResponse> handleGet8(Object request) => throw UnimplementedError();
+@CloudFunction()
+Future<_MyResponse> customResponseAsync(Object request) =>
+    throw UnimplementedError();
 
-//@CloudFunction('more specific return type - FutureOr')
-FutureOr<_MyResponse> handleGet9(Object request) => throw UnimplementedError();
+@CloudFunction()
+FutureOr<_MyResponse> customResponseFutureOr(Object request) =>
+    throw UnimplementedError();
 
 abstract class _MyResponse extends Response {
   _MyResponse(int statusCode) : super(statusCode);

--- a/test/hello/bin/server.dart
+++ b/test/hello/bin/server.dart
@@ -13,5 +13,5 @@ Future<void> main(List<String> args) async {
 }
 
 const _functions = <String, Handler>{
-  'function': function_library.handleGet,
+  'function': function_library.function,
 };

--- a/test/hello/lib/functions.dart
+++ b/test/hello/lib/functions.dart
@@ -22,10 +22,11 @@ import 'package:shelf/shelf.dart';
 int _activeRequests = 0;
 int _maxActiveRequests = 0;
 int _requestCount = 0;
+
 final _watch = Stopwatch();
 
 @CloudFunction()
-Future<Response> handleGet(Request request) async {
+Future<Response> function(Request request) async {
   _watch.start();
   _requestCount++;
   _activeRequests++;
@@ -65,7 +66,7 @@ Future<Response> handleGet(Request request) async {
       };
 
       return Response.ok(
-        JsonUtf8Encoder('  ').convert(output),
+        _encoder.convert(output),
         headers: _jsonHeaders,
       );
     }
@@ -100,4 +101,8 @@ Future<Response> handleGet(Request request) async {
 
 final _helloWorldBytes = utf8.encode('Hello, World!');
 
-const _jsonHeaders = {'Content-Type': 'application/json'};
+const _contentTypeHeader = 'Content-Type';
+const _jsonContentType = 'application/json';
+const _jsonHeaders = {_contentTypeHeader: _jsonContentType};
+
+const _encoder = JsonEncoder.withIndent(' ');

--- a/test/hello/pubspec.yaml
+++ b/test/hello/pubspec.yaml
@@ -14,6 +14,7 @@ dev_dependencies:
   build_verify: ^1.1.1
   functions_framework_builder: any
   http: ^0.12.0
+  http_parser: ^3.1.4
   io: ^0.3.4
   test: ^1.15.0
   test_process: ^1.0.0

--- a/test/hello/test/cloud_behavior_test.dart
+++ b/test/hello/test/cloud_behavior_test.dart
@@ -161,7 +161,7 @@ void main() {
         isA<String>(), // spec says this should be a String
       ),
     );
-    expect(sourceLocation, containsPair('function', 'handleGet'));
+    expect(sourceLocation, containsPair('function', 'function'));
 
     lines.clear();
   });
@@ -212,7 +212,7 @@ void main() {
         sourceLocation,
         containsPair(
           'function',
-          startsWith('handleGet'),
+          startsWith('function'),
         ),
       );
     }

--- a/test/hello/test/cloud_behavior_test.dart
+++ b/test/hello/test/cloud_behavior_test.dart
@@ -50,7 +50,7 @@ void main() {
     runFuture = runZoned(
       () => run(
         0,
-        handleGet,
+        function,
         completionSignal.future,
         cloudLoggingMiddleware(_projectId),
       ),


### PR DESCRIPTION
If `target` is not provided, the name of the function is now used

Now properly reject private functions
Now reject functions annotated twice
