### PR TITLE
test/hello: split tests into multiple, focused files

### DIFF
--- a/test/hello/test/cli_test.dart
+++ b/test/hello/test/cli_test.dart
@@ -1,0 +1,221 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@Timeout(Duration(seconds: 3))
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart';
+import 'package:io/io.dart';
+import 'package:test/test.dart';
+
+import 'src/test_utils.dart';
+
+void main() {
+  test('defaults', () async {
+    final proc = await startServerTest();
+
+    final response = await get('http://localhost:$defaultPort');
+    expect(response.statusCode, 200);
+    expect(response.body, 'Hello, World!');
+
+    await finishServerTest(proc);
+  });
+
+  test('SIGINT also terminates the server', () async {
+    final proc = await startServerTest();
+
+    final response = await get('http://localhost:$defaultPort');
+    expect(response.statusCode, 200);
+    expect(response.body, 'Hello, World!');
+
+    await finishServerTest(proc, signal: ProcessSignal.sigint);
+  });
+
+  test('good options', () async {
+    const port = 9000;
+    final proc = await startServerTest(
+      expectedListeningPort: port,
+      arguments: [
+        '--port',
+        port.toString(),
+        '--target',
+        'function',
+        '--signature-type',
+        'http'
+      ],
+      env: {
+        // make sure args have precedence over environment
+        'FUNCTION_TARGET': 'foo', // overridden by --target
+        'FUNCTION_SIGNATURE_TYPE':
+            'cloudevent', // overridden by --signature-type
+      },
+    );
+
+    final response = await get('http://localhost:$port');
+    expect(response.statusCode, 200);
+    expect(response.body, 'Hello, World!');
+
+    await finishServerTest(proc);
+  });
+
+  group('environment', () {
+    test('good environment', () async {
+      const port = 8888;
+      final proc = await startServerTest(expectedListeningPort: port, env: {
+        'PORT': port.toString(),
+      });
+
+      final response = await get('http://localhost:$port');
+      expect(response.statusCode, 200);
+      expect(response.body, 'Hello, World!');
+
+      await finishServerTest(proc);
+    });
+
+    test('bad FUNCTION_TARGET', () async {
+      final proc = await startServerTest(shouldFail: true, env: {
+        'FUNCTION_TARGET': 'bob',
+      });
+
+      await expectLater(
+        proc.stderr,
+        emitsThrough(
+          'There is no handler configured for FUNCTION_TARGET `bob`.',
+        ),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+
+    test('bad FUNCTION_SIGNATURE_TYPE', () async {
+      final proc = await startServerTest(shouldFail: true, env: {
+        'FUNCTION_SIGNATURE_TYPE': 'bob',
+      });
+
+      await expectLater(
+        proc.stderr,
+        emitsThrough(
+          'FUNCTION_SIGNATURE_TYPE environment variable "bob" is not a valid '
+          'option (must be "http" or "cloudevent")',
+        ),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+
+    test('bad PORT', () async {
+      final proc = await startServerTest(shouldFail: true, env: {
+        'PORT': 'bob',
+      });
+
+      await expectLater(
+        proc.stderr,
+        emitsThrough(
+          'Bad value for environment variable "PORT" – "bob" – '
+          'Invalid radix-10 number.',
+        ),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+  });
+
+  group('command line', () {
+    test('unsupported option', () async {
+      final proc = await startServerTest(
+        shouldFail: true,
+        arguments: [
+          '--bob',
+        ],
+      );
+
+      await expectLater(
+        proc.stderr,
+        emitsInOrder([
+          'Could not find an option named "bob".',
+          ...LineSplitter.split(_usage),
+        ]),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+
+    test('bad target', () async {
+      final proc = await startServerTest(
+        shouldFail: true,
+        arguments: [
+          '--target',
+          'bob',
+        ],
+      );
+
+      await expectLater(
+        proc.stderr,
+        emitsThrough(
+          'There is no handler configured for FUNCTION_TARGET `bob`.',
+        ),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+
+    test('bad signature', () async {
+      final proc = await startServerTest(
+        shouldFail: true,
+        arguments: ['--signature-type', 'foo'],
+      );
+
+      await expectLater(
+        proc.stderr,
+        emitsInOrder([
+          '"foo" is not an allowed value for option "signature-type".',
+          ...LineSplitter.split(_usage),
+        ]),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+
+    test('bad port', () async {
+      final proc = await startServerTest(
+        shouldFail: true,
+        arguments: ['--port', 'foo'],
+      );
+
+      await expectLater(
+        proc.stderr,
+        emitsInOrder([
+          'Bad value for "port" – "foo" – Invalid radix-10 number.',
+          ...LineSplitter.split(_usage),
+        ]),
+      );
+
+      await proc.shouldExit(ExitCode.usage.code);
+    });
+  });
+}
+
+const _usage = r'''
+--port              The port on which the Functions Framework listens for
+                    requests.
+                    Overrides the PORT environment variable.
+--target            The name of the exported function to be invoked in response
+                    to requests.
+                    Overrides the FUNCTION_TARGET environment variable.
+--signature-type    The signature used when writing your function. Controls
+                    unmarshalling rules and determines which arguments are used
+                    to invoke your function.
+                    Overrides the FUNCTION_SIGNATURE_TYPE environment variable.
+                    [http, cloudevent]''';

--- a/test/hello/test/cloud_event_test.dart
+++ b/test/hello/test/cloud_event_test.dart
@@ -1,0 +1,153 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@Timeout(Duration(seconds: 3))
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+import 'src/test_utils.dart';
+
+void main() {
+  // TODO: non-JSON body
+  // TODO: JSON-body, but not a Map
+  // TODO: JSON-body is a map, but wrong/missing keys/values
+  // TODO: invalid header value encoding (bad date time, for instance)
+  // TODO: proper error logging when hosted on cloud
+
+  test('binary-mode message', () async {
+    final proc = await startServerTest(
+      arguments: [
+        '--target',
+        'basicCloudEventHandler',
+        '--signature-type',
+        'cloudevent',
+      ],
+      expectedListeningPort: 0,
+    );
+
+    final requestUrl = 'http://localhost:$autoPort/';
+
+    const body = r'''
+{
+ "subscription": "projects/my-project/subscriptions/my-subscription",
+ "message": {
+   "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+   "attributes": {
+     "attr1":"attr1-value"
+   },
+   "data": "dGVzdCBtZXNzYWdlIDM="
+ }
+}''';
+
+    final response = await post(
+      requestUrl,
+      body: body,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'ce-specversion': '1.0',
+        'ce-type': 'google.cloud.pubsub.topic.publish',
+        'ce-time': '2020-09-05T03:56:24Z',
+        'ce-id': '1234-1234-1234',
+        'ce-source': 'urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66',
+      },
+    );
+    expect(response.statusCode, 200);
+    expect(response.body, isEmpty);
+
+    await finishServerTest(
+      proc,
+      requestOutput: endsWith('POST    [200] /'),
+    );
+
+    final stderrOutput = await proc.stderrStream().join('\n');
+
+    final json = jsonDecode(stderrOutput) as Map<String, dynamic>;
+
+    expect(
+      json,
+      {
+        'id': '1234-1234-1234',
+        'specversion': '1.0',
+        'type': 'google.cloud.pubsub.topic.publish',
+        'datacontenttype': 'application/json; charset=utf-8',
+        'time': '2020-09-05T03:56:24.000Z',
+        'source': 'urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66',
+        'data': jsonDecode(body),
+      },
+    );
+  });
+
+  test('structured-mode message', () async {
+    final proc = await startServerTest(
+      arguments: [
+        '--target',
+        'basicCloudEventHandler',
+        '--signature-type',
+        'cloudevent',
+      ],
+      expectedListeningPort: 0,
+    );
+
+    final requestUrl = 'http://localhost:$autoPort/';
+
+    const body = r'''
+{
+  "specversion": "1.0",
+  "type": "google.cloud.pubsub.topic.publish",
+  "time": "2020-09-05T03:56:24.000Z",
+  "id": "1234-1234-1234",
+  "data": {
+    "subscription": "projects/my-project/subscriptions/my-subscription",
+    "message": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+        "attr1":"attr1-value"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+    }
+  }
+}''';
+
+    final response = await post(
+      requestUrl,
+      body: body,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+    );
+    expect(response.statusCode, 200);
+    expect(response.body, isEmpty);
+
+    await finishServerTest(
+      proc,
+      requestOutput: endsWith('POST    [200] /'),
+    );
+
+    final stderrOutput = await proc.stderrStream().join('\n');
+
+    addTearDown(() {
+      final json = jsonDecode(stderrOutput) as Map<String, dynamic>;
+
+      expect(
+        json,
+        {
+          ...jsonDecode(body) as Map<String, dynamic>,
+          'datacontenttype': 'application/json; charset=utf-8',
+        },
+      );
+    });
+  });
+}

--- a/test/hello/test/src/test_utils.dart
+++ b/test/hello/test/src/test_utils.dart
@@ -1,0 +1,80 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
+
+const defaultPort = 8080;
+
+int _autoPort;
+
+int get autoPort => _autoPort;
+
+Future<TestProcess> startServerTest({
+  bool shouldFail = false,
+  int expectedListeningPort = defaultPort,
+  Map<String, String> env,
+  Iterable<String> arguments = const <String>[],
+}) async {
+  if (expectedListeningPort == 0) {
+    expect(arguments, isNot(contains('--port')));
+    if (env != null) {
+      expect(env, isNot(contains('PORT')));
+    }
+  }
+  final args = [
+    'bin/server.dart',
+    ...arguments,
+    if (expectedListeningPort == 0) ...['--port', '0'],
+  ];
+  final proc = await TestProcess.start('dart', args, environment: env);
+
+  if (!shouldFail) {
+    final output = await proc.stdout.next;
+    final match = _listeningPattern.firstMatch(output);
+    expect(match, isNotNull);
+    _autoPort = int.parse(match[1]);
+    if (expectedListeningPort == 0) {
+      expect(_autoPort, greaterThan(0));
+    } else {
+      expect(_autoPort, expectedListeningPort);
+    }
+  }
+
+  return proc;
+}
+
+final _listeningPattern = RegExp(r'Listening on :(\d+)');
+
+Future<void> finishServerTest(
+  TestProcess proc, {
+  ProcessSignal signal = ProcessSignal.sigterm,
+  Object requestOutput,
+}) async {
+  requestOutput ??= endsWith('GET     [200] /');
+  await expectLater(
+    proc.stdout,
+    requestOutput is StreamMatcher
+        ? requestOutput
+        : emitsThrough(requestOutput),
+  );
+  proc.signal(signal);
+  await proc.shouldExit(0);
+  await expectLater(
+    proc.stdout,
+    emitsThrough('Received signal $signal - closing'),
+  );
+}


### PR DESCRIPTION
Move common utilities to shared library
Make it easy to run tests with a random listening port
  This makes sure we don't have two tests running in parallel that
  collide on 8080
