### PR TITLE
i80 bad request log level

### DIFF
--- a/functions_framework/lib/src/log_severity.dart
+++ b/functions_framework/lib/src/log_severity.dart
@@ -16,6 +16,7 @@
 class LogSeverity implements Comparable<LogSeverity> {
   static const debug = LogSeverity._(100, 'DEBUG');
   static const info = LogSeverity._(200, 'INFO');
+  static const warning = LogSeverity._(400, 'WARNING');
   static const error = LogSeverity._(500, 'ERROR');
 
   final int value;

--- a/functions_framework/lib/src/logging.dart
+++ b/functions_framework/lib/src/logging.dart
@@ -117,7 +117,7 @@ Middleware cloudLoggingMiddleware(String projectid) {
                   ? createLogEntry(
                       'Bad request. ${error.message}',
                       error.innerStack ?? stackTrace,
-                      LogSeverity.debug,
+                      LogSeverity.warning,
                       // Since the error should have been raised within the
                       // framework, we want to see the stack within
                       // functions_framework

--- a/test/hello/test/cloud_behavior_test.dart
+++ b/test/hello/test/cloud_behavior_test.dart
@@ -174,7 +174,7 @@ void main() {
         startsWith('Bad request. Content-Type header is required.'),
         'package:functions_framework/src/cloud_event_wrapper.dart',
         '_mediaTypeFromRequest',
-        severity: 'DEBUG',
+        severity: 'WARNING',
       );
       lines.clear();
     });
@@ -215,7 +215,7 @@ void main() {
         ),
         startsWith('package:functions_framework/src/'),
         isNotEmpty,
-        severity: 'DEBUG',
+        severity: 'WARNING',
       );
       lines.clear();
     });


### PR DESCRIPTION
- make a cloud event handler THE handler
- Log bad request details at the same level as a 400 response: warning
