### PR TITLE
Remove CI table from `functions_framework` readme

### DIFF
--- a/functions_framework/README.md
+++ b/functions_framework/README.md
@@ -2,6 +2,8 @@
 
 > DISCLAIMER: this is not ready for production.
 
+[![pub package](https://img.shields.io/pub/v/functions_framework.svg)](https://pub.dev/packages/functions_framework)
+
 An open source FaaS (Function as a Service) framework for writing portable Dart functions,
 brought to you by the Google Dart and Cloud Functions teams.
 

--- a/functions_framework/README.md
+++ b/functions_framework/README.md
@@ -2,10 +2,6 @@
 
 > DISCLAIMER: this is not ready for production.
 
-|Functions Framework|Unit Tests|Lint Test|Conformance Tests|
-|---|---|---|---|
-[Dart][ff_dart]| [![][ff_dart_unit_img]][ff_dart_unit_link] | [![][ff_dart_lint_img]][ff_dart_lint_link] | [![][ff_dart_conformance_img]][ff_dart_conformance_link] |
-
 An open source FaaS (Function as a Service) framework for writing portable Dart functions,
 brought to you by the Google Dart and Cloud Functions teams.
 


### PR DESCRIPTION
It's fine just to have this in the root, right?