### PR TITLE
Need a blank line after br tag

### DIFF
--- a/docs/quick-starts/03-quick-start-cloud-run.md
+++ b/docs/quick-starts/03-quick-start-cloud-run.md
@@ -92,6 +92,7 @@ Service URL: https://hello-gpua4upw6q-uc.a.run.app
 ```
 
 <br>
+
 **Congratulations!** You have successfully built and deployed your function 
 to Cloud Run. You can now access your function at the Service URL that is
 printed in the last line of output.


### PR DESCRIPTION
Without blank line, breaks bold for `**Congratulations!**`.