### PR TITLE
Fix quick start for Cloud Run

### DIFF
--- a/docs/quick-starts/03-quick-start-cloud-run.md
+++ b/docs/quick-starts/03-quick-start-cloud-run.md
@@ -72,7 +72,7 @@ same for platform and region and omit the arguments from the command line.
 
 ```shell
 gcloud config set run/platform managed
-gcloud config set compute/region us-central1
+gcloud config set run/region us-central1
 ```
 
 For example:


### PR DESCRIPTION
Minor edit: should be `run/region` for Cloud Run, not `compute/region`