### PR TITLE
Remove trailing whitespace

### DIFF
--- a/docs/quickstarts/02-quickstart-docker.md
+++ b/docs/quickstarts/02-quickstart-docker.md
@@ -160,7 +160,7 @@ You can have multiple simultaneously running containers with processes listening
 on port `8080` on the same host, as long as each container is mapped to a unique
 host port (a unique port on localhost).
 
-Nevertheless, if you really want to change the container port (the port the 
+Nevertheless, if you really want to change the container port (the port the
 server binds to **inside** of the container) for some reason, you can do so as
 shown below.
 


### PR DESCRIPTION
Don't know how the following slipped through CI, but fixed now.

```
$ markdownlint-cli2 "**/*.md"
markdownlint-cli2 v0.0.13 (markdownlint v0.22.0)
Finding: **/*.md
Linting: 15 file(s)
Summary: 1 error(s)
docs/quickstarts/02-quickstart-docker.md:163:76 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
```
