### PR TITLE
Prepare to release v0.3.0 of functions_framework_builder

### DIFF
--- a/examples/json/pubspec.yaml
+++ b/examples/json/pubspec.yaml
@@ -18,7 +18,5 @@ dev_dependencies:
   test_process: ^1.0.0
 
 dependency_overrides:
-  functions_framework:
-    path: ../../functions_framework
   functions_framework_builder:
     path: ../../functions_framework_builder

--- a/examples/raw_cloudevent/pubspec.yaml
+++ b/examples/raw_cloudevent/pubspec.yaml
@@ -16,7 +16,5 @@ dev_dependencies:
   test_process: ^1.0.0
 
 dependency_overrides:
-  functions_framework:
-    path: ../../functions_framework
   functions_framework_builder:
     path: ../../functions_framework_builder

--- a/functions_framework_builder/CHANGELOG.md
+++ b/functions_framework_builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0-dev
+## 0.3.0
 
 - Added support for connecting functions that handle and return JSON data.
 - Added support for connecting functions that handle the `CloudEvent` type.

--- a/functions_framework_builder/pubspec.yaml
+++ b/functions_framework_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: functions_framework_builder
-version: 0.3.0-dev
+version: 0.3.0
 description: Builder for package:functions_framework
 repository: https://github.com/GoogleCloudPlatform/functions-framework-dart
 
@@ -11,8 +11,9 @@ dependencies:
   build: ^1.3.0
   build_config: ^0.4.3
   dart_style: ^1.3.10
-  # TODO: put back version tight version constraint before publish
-  functions_framework: any
+  # There is a tight version constraint because the builder has a strict
+  # dependency on all features exposed.
+  functions_framework: '>=0.3.0 <0.3.1'
   glob: ^1.2.0
   meta: ^1.2.4
   path: ^1.7.0
@@ -24,7 +25,3 @@ dev_dependencies:
   package_config: ^1.9.3
   stream_transform: ^1.2.0
   test: ^1.15.7
-
-dependency_overrides:
-  functions_framework:
-    path: ../functions_framework


### PR DESCRIPTION
Also dropped dev_dependecy on function_framework in two examples
