### PR TITLE
Rename tool pub name to dartfn

### DIFF
--- a/functions_framework_tool/CHANGELOG.md
+++ b/functions_framework_tool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+- Renamed the package to `dartfn` so `dart pub global activate dartfn` works.
+
 ## 0.3.0
 
 The first version is `0.3.0` to align with the rest of published Functions

--- a/functions_framework_tool/README.md
+++ b/functions_framework_tool/README.md
@@ -96,7 +96,7 @@ dartfn version
 Output
 
 ```text
-Google Functions Framework for Dart CLI (dartfn) version: 0.3.0
+Google Functions Framework for Dart CLI (dartfn) version: 0.3.1
 ```
 
 If a newer version is available, the command will inform  you. Example:
@@ -105,11 +105,11 @@ If a newer version is available, the command will inform  you. Example:
 dartfn version
 ```
 
-Output
+Output (hypothetical update available)
 
 ```text
-Google Functions Framework for Dart CLI (dartfn) version: 0.2.0
-Version 0.3.0 is available! To update to this version, run: `pub global activate dartfn`.
+Google Functions Framework for Dart CLI (dartfn) version: 0.3.1
+Version 0.3.2 is available! To update to this version, run: `pub global activate dartfn`.
 ```
 
 If you just want the version number, use the `-s` or `--short` option:
@@ -121,5 +121,6 @@ dartfn version --short
 Output
 
 ```text
-0.3.0
+0.3.1
 ```
+

--- a/functions_framework_tool/README.md
+++ b/functions_framework_tool/README.md
@@ -1,4 +1,4 @@
-# Functions Framework Tool package for Dart
+# Functions Framework Tool package for Dart: dartfn
 
 This package is intended to support tools for working with Functions Framework
 projects.

--- a/functions_framework_tool/bin/dartfn.dart
+++ b/functions_framework_tool/bin/dartfn.dart
@@ -18,8 +18,8 @@ import 'dart:io' as io;
 import 'package:io/io.dart' show ExitCode;
 
 import 'package:args/command_runner.dart';
-import 'package:functions_framework_tool/functions_framework_tool.dart' as tool;
-import 'package:functions_framework_tool/src/cli/app.dart' as cli;
+import 'package:dartfn/functions_framework_tool.dart' as tool;
+import 'package:dartfn/src/cli/app.dart' as cli;
 
 // Initialize the CLI app with a list of generators and a terminal printer.
 // Process args and/or execute a subcommand. Always exit immediately when the

--- a/functions_framework_tool/build.yaml
+++ b/functions_framework_tool/build.yaml
@@ -9,13 +9,13 @@ targets:
         - templates/**
         - tool/**
     builders:
-      functions_framework_tool:
+      dartfn:
         generate_for:
           - lib/src/generators/*.dart
         enabled: true
 
 builders:
-  functions_framework_tool:
+  dartfn:
     import: "tool/builder/builder.dart"
     builder_factories: ["builder"]
     build_extensions: {".dart": [".g.dart"]}

--- a/functions_framework_tool/lib/src/version.dart
+++ b/functions_framework_tool/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.0';
+const packageVersion = '0.3.1';

--- a/functions_framework_tool/pubspec.yaml
+++ b/functions_framework_tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: dartfn
 description: >
   A tools package for managing FaaS (Function as a service) portable Dart functions projects
 # After changing the version, run `pub run build_runner build`.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/GoogleCloudPlatform/functions-framework-dart
 
 environment:

--- a/functions_framework_tool/pubspec.yaml
+++ b/functions_framework_tool/pubspec.yaml
@@ -1,4 +1,4 @@
-name: functions_framework_tool
+name: dartfn
 description: >
   A tools package for managing FaaS (Function as a service) portable Dart functions projects
 # After changing the version, run `pub run build_runner build`.


### PR DESCRIPTION
So that users can just run:

```shell
dart pub global activate dartfn
```

instead of

```shell
dart pub global activate functions_framework_tool
```
