### PR TITLE
Add fix for sigterm error on windows to changelog

### DIFF
--- a/functions_framework/CHANGELOG.md
+++ b/functions_framework/CHANGELOG.md
@@ -8,6 +8,8 @@
     - Added `request` property to access original request.
     - Deprecated `headers` and `headersAll` - use `request` instead.
 
+  - Fix exception on Windows due to SIGTERM handler ([PR #153]).
+
 ## 0.3.0
 
 - Added support for functions that handle and return JSON data.
@@ -50,3 +52,7 @@
 This is a preview release of the Functions Framework for Dart to demonstrate
 http functions support only (cloudevent support is not yet implemented). This
 is a work in progress and currently does not pass conformance testing.
+
+<!-- Reference links -->
+[pr #153]:
+https://github.com/GoogleCloudPlatform/functions-framework-dart/issues/151

--- a/functions_framework/CHANGELOG.md
+++ b/functions_framework/CHANGELOG.md
@@ -7,7 +7,6 @@
   - `RequestContext`
     - Added `request` property to access original request.
     - Deprecated `headers` and `headersAll` - use `request` instead.
-
   - Fix exception on Windows due to SIGTERM handler ([PR #153]).
 
 ## 0.3.0


### PR DESCRIPTION
I've updated the changelog for `functions_framework`. However, I think we should get this published so Windows devs aren't blocked. I can either bump `0.3.1-dev` in the changelog and pubspec to `0.3.1` with this PR or with a following PR so we can publish the fix.