### PR TITLE
docs: add requirements to fullstack example readme

### DIFF
--- a/examples/fullstack/README.md
+++ b/examples/fullstack/README.md
@@ -13,6 +13,10 @@ JSON-encoded request body and returns a JSON-encoded response body. For the
 demo, the function is hosted on `localhost` and on [Cloud Run], a fully
 managed serverless platform on [Google Cloud].
 
+## Requirements
+
+- Dart: >=2.12.0 <3.0.0
+
 ## Build and deploy the backend
 
 Change directory to `backend`.

--- a/examples/fullstack/frontend/README.md
+++ b/examples/fullstack/frontend/README.md
@@ -15,7 +15,9 @@ demo.
 Before beginning, enable macos development:
 
 ```shell
+flutter config --enable-windows-desktop
 flutter config --enable-macos-desktop
+flutter config --enable-linux-desktop
 ```
 
 Configuration for `dev` and `prod` environments is stored under `assets/config`.

--- a/examples/fullstack/frontend/README.md
+++ b/examples/fullstack/frontend/README.md
@@ -14,7 +14,7 @@ demo.
 
 Before beginning, enable macos development:
 
-```
+```shell
 flutter config --enable-macos-desktop
 ```
 

--- a/examples/fullstack/frontend/README.md
+++ b/examples/fullstack/frontend/README.md
@@ -6,7 +6,17 @@ demo.
 > NOTE: The desktop app currently has only been tested on macOS. Testing on
 > Linux or Windows and help with updating docs is appreciated!
 
+## Requirements
+
+- [Flutter](https://flutter.dev/docs/get-started/install)
+
 ## Environment
+
+Before beginning, enable macos development:
+
+```
+flutter config --enable-macos-desktop
+```
 
 Configuration for `dev` and `prod` environments is stored under `assets/config`.
 


### PR DESCRIPTION
Adds requirements for the fullstack demo.

I wasn't able to run the application without these requirements (probably already setup for y'all).