### PR TITLE
 Add launch.json for vscode

### DIFF
--- a/dartfn/templates/cloudevent/.vscode/launch.json
+++ b/dartfn/templates/cloudevent/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/dartfn/templates/cloudevent/.vscode/tasks.json
+++ b/dartfn/templates/cloudevent/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/dartfn/templates/helloworld/.vscode/launch.json
+++ b/dartfn/templates/helloworld/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/dartfn/templates/helloworld/.vscode/tasks.json
+++ b/dartfn/templates/helloworld/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/dartfn/templates/json/.vscode/launch.json
+++ b/dartfn/templates/json/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/dartfn/templates/json/.vscode/tasks.json
+++ b/dartfn/templates/json/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/examples/fullstack/.vscode/launch.json
+++ b/examples/fullstack/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "/backend/bin/server.dart"
+    }
+  ]
+}

--- a/examples/fullstack/.vscode/tasks.json
+++ b/examples/fullstack/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "options": {
+        "cwd": "/backend"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/examples/hello/.vscode/launch.json
+++ b/examples/hello/.vscode/launch.json
@@ -4,7 +4,8 @@
       "name": "Launch Function",
       "type": "dart",
       "request": "launch",
-      "program": "bin/server.dart"
+      "program": "bin/server.dart",
+      "preLaunchTask": "Build"
     }
   ]
 }

--- a/examples/hello/.vscode/launch.json
+++ b/examples/hello/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/examples/hello/.vscode/tasks.json
+++ b/examples/hello/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/examples/json/.vscode/launch.json
+++ b/examples/json/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/examples/json/.vscode/tasks.json
+++ b/examples/json/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/examples/raw_cloudevent/.vscode/launch.json
+++ b/examples/raw_cloudevent/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Function",
+      "type": "dart",
+      "request": "launch",
+      "program": "bin/server.dart"
+    }
+  ]
+}

--- a/examples/raw_cloudevent/.vscode/tasks.json
+++ b/examples/raw_cloudevent/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "dart",
+      "command": "dart",
+      "args": [
+        "run",
+        "build_runner",
+        "build",
+        "--delete-conflicting-outputs"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds launch.json files to all examples and `dartfn` templates so that a "Launch Function" command is added to the "Run & Debug" panel if opening one of those projects in vscode.This makes it slightly cleaner for those using vscode (which I suspect is most Dart developers), and it allows you to debug the functions as well, which I think is super nice. For people coming from Flutter, this could be a nice quality of life improvement change when they try an example for the first time.

Thanks!