### PR TITLE
fix: restrict version of build_version to avoid generation error

### DIFF
--- a/dartfn/pubspec.yaml
+++ b/dartfn/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   build_config: ^1.0.0
   build_runner: ^2.0.4
   build_verify: ^2.0.0
-  build_version: ^2.0.1
+  build_version: '>=2.0.1 <2.1.0'
   glob: ^2.0.0
   grinder: ^0.9.0
   lints: ^1.0.0


### PR DESCRIPTION
With the latest version of pkg:build_version, version files are created
for templates. Avoid that issue until we can figure out a work-around

Fixes CI failure
