### PR TITLE
Added customMiddleware to allow for easy request intercepting

### DIFF
--- a/examples/fullstack/backend/bin/server.dart
+++ b/examples/fullstack/backend/bin/server.dart
@@ -21,7 +21,6 @@ Future<void> main(List<String> args) async {
   await serve(
     args,
     _nameToFunctionTarget,
-    autoCompress: true,
     customMiddleware: corsHeaders(),
   );
 }

--- a/examples/fullstack/backend/bin/server.dart
+++ b/examples/fullstack/backend/bin/server.dart
@@ -15,9 +15,15 @@
 
 import 'package:backend/functions.dart' as function_library;
 import 'package:functions_framework/serve.dart';
+import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 
 Future<void> main(List<String> args) async {
-  await serve(args, _nameToFunctionTarget);
+  await serve(
+    args,
+    _nameToFunctionTarget,
+    autoCompress: true,
+    customMiddleware: corsHeaders(),
+  );
 }
 
 FunctionTarget? _nameToFunctionTarget(String name) {

--- a/examples/fullstack/backend/pubspec.lock
+++ b/examples/fullstack/backend/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "29.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.8"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.2"
+    version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.4"
   charcode:
     dependency: transitive
     description:
@@ -106,13 +106,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   code_builder:
     dependency: transitive
     description:
@@ -126,7 +119,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -140,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -154,7 +147,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   file:
     dependency: transitive
     description:
@@ -179,17 +172,17 @@ packages:
   functions_framework:
     dependency: "direct main"
     description:
-      name: functions_framework
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.1"
+      path: "../../../functions_framework"
+      relative: true
+    source: path
+    version: "0.4.2-dev"
   functions_framework_builder:
     dependency: "direct dev"
     description:
       name: functions_framework_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.4"
+    version: "0.4.5"
   glob:
     dependency: transitive
     description:
@@ -217,7 +210,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -238,21 +231,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.5"
   lints:
     dependency: "direct dev"
     description:
@@ -287,7 +280,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
@@ -308,7 +301,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -322,14 +315,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   shelf:
     dependency: "direct main"
     description:
@@ -337,6 +330,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  shelf_cors_headers:
+    dependency: "direct main"
+    description:
+      name: shelf_cors_headers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -364,14 +364,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -392,7 +392,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -434,21 +434,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.2"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.11"
   test_process:
     dependency: "direct dev"
     description:
@@ -476,7 +476,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -506,4 +506,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/examples/fullstack/backend/pubspec.yaml
+++ b/examples/fullstack/backend/pubspec.yaml
@@ -2,18 +2,25 @@ name: backend
 publish_to: none
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  functions_framework: ^0.4.0
+  functions_framework: ^0.4.2
   json_annotation: ^4.3.0
-  shelf: ^1.0.0
+  shelf: ^1.2.0
+  shelf_cors_headers: ^0.1.2
+
+# Override required until 0.4.2 is released as the new attributes do not yet
+# exist in 0.4.1
+dependency_overrides:
+  functions_framework:
+    path: ../../../functions_framework
 
 dev_dependencies:
   build_runner: ^2.0.0
   functions_framework_builder: ^0.4.0
   http: ^0.13.0
   json_serializable: ^6.0.0
-  lints: ^1.0.0
+  lints: ^1.0.1
   test: ^1.15.7
   test_process: ^2.0.0

--- a/examples/fullstack/frontend-cli/pubspec.lock
+++ b/examples/fullstack/frontend-cli/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "29.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.8"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.2"
+    version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.4"
   charcode:
     dependency: transitive
     description:
@@ -106,13 +106,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   code_builder:
     dependency: transitive
     description:
@@ -126,7 +119,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -140,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -154,7 +147,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   file:
     dependency: transitive
     description:
@@ -203,7 +196,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -224,21 +217,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.5"
   lints:
     dependency: "direct dev"
     description:
@@ -273,7 +266,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
@@ -294,7 +287,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -308,14 +301,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   shelf:
     dependency: transitive
     description:
@@ -350,14 +343,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -378,7 +371,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -420,21 +413,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.2"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.11"
   timing:
     dependency: transitive
     description:
@@ -455,7 +448,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -485,4 +478,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/examples/fullstack/frontend/pubspec.lock
+++ b/examples/fullstack/frontend/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "29.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.8"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.2"
+    version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.4"
   characters:
     dependency: transitive
     description:
@@ -113,13 +113,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -161,14 +154,14 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   fake_async:
     dependency: transitive
     description:
@@ -234,7 +227,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -255,21 +248,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.5"
   logging:
     dependency: transitive
     description:
@@ -284,6 +277,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -297,7 +297,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   nested:
     dependency: transitive
     description:
@@ -332,21 +332,21 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   shelf:
     dependency: transitive
     description:
@@ -372,14 +372,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   source_span:
     dependency: transitive
     description:
@@ -428,7 +428,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:
@@ -472,5 +472,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=1.16.0"

--- a/examples/fullstack/frontend/windows/flutter/generated_plugin_registrant.cc
+++ b/examples/fullstack/frontend/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 

--- a/examples/fullstack/frontend/windows/flutter/generated_plugin_registrant.h
+++ b/examples/fullstack/frontend/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/functions_framework/CHANGELOG.md
+++ b/functions_framework/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.2-dev
 
 - Requires Dart `2.14.0`.
+- Added `autoCompress` and `middlewares` as optional parameters to `serve`
 
 ## 0.4.1
 

--- a/functions_framework/CHANGELOG.md
+++ b/functions_framework/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.4.2-dev
 
 - Requires Dart `2.14.0`.
-- Added `autoCompress` and `middlewares` as optional parameters to `serve`
+- Added `autoCompress` and `customMiddleware` as optional parameters to `serve`
 
 ## 0.4.1
 

--- a/functions_framework/lib/serve.dart
+++ b/functions_framework/lib/serve.dart
@@ -50,10 +50,10 @@ Future<void> serve(
   List<String> args,
   FunctionTarget? Function(String) nameToFunctionTarget, {
   bool autoCompress = false,
-  List<Middleware> middlewares = const [],
+  Middleware? customMiddleware,
 }) async {
   try {
-    await _serve(args, nameToFunctionTarget, autoCompress, middlewares);
+    await _serve(args, nameToFunctionTarget, autoCompress, customMiddleware);
   } on BadConfigurationException catch (e) {
     stderr.writeln(red.wrap(e.message));
     if (e.details != null) {
@@ -67,7 +67,7 @@ Future<void> _serve(
   List<String> args,
   FunctionTarget? Function(String) nameToFunctionTarget,
   bool autoCompress,
-  List<Middleware> middlewares,
+  Middleware? customMiddleware,
 ) async {
   final configFromEnvironment = FunctionConfig.fromEnv();
 
@@ -127,12 +127,15 @@ Future<void> _serve(
     sigTermSub = ProcessSignal.sigterm.watch().listen(signalHandler);
   }
 
+  if (customMiddleware != null) {
+    loggingMiddleware.addMiddleware(customMiddleware);
+  }
+
   await run(
     config.port,
     functionTarget.handler,
     completer.future,
     loggingMiddleware,
     autoCompress: autoCompress,
-    middlewares: middlewares,
   );
 }

--- a/functions_framework/lib/src/run.dart
+++ b/functions_framework/lib/src/run.dart
@@ -22,8 +22,14 @@ Future<void> run(
   int port,
   Handler handler,
   Future<bool> shutdownSignal,
-  Middleware loggingMiddleware,
-) async {
+  Middleware loggingMiddleware, {
+  bool autoCompress = false,
+  List<Middleware> middlewares = const [],
+}) async {
+  for (var m in middlewares) {
+    loggingMiddleware.addMiddleware(m);
+  }
+
   final server = await shelf_io.serve(
     loggingMiddleware
         .addMiddleware(_forbiddenAssetMiddleware)
@@ -31,6 +37,7 @@ Future<void> run(
     InternetAddress.anyIPv4,
     port,
   );
+  server.autoCompress = autoCompress;
   print('Listening on :${server.port}');
 
   final force = await shutdownSignal;

--- a/functions_framework/lib/src/run.dart
+++ b/functions_framework/lib/src/run.dart
@@ -24,12 +24,7 @@ Future<void> run(
   Future<bool> shutdownSignal,
   Middleware loggingMiddleware, {
   bool autoCompress = false,
-  List<Middleware> middlewares = const [],
 }) async {
-  for (var m in middlewares) {
-    loggingMiddleware.addMiddleware(m);
-  }
-
   final server = await shelf_io.serve(
     loggingMiddleware
         .addMiddleware(_forbiddenAssetMiddleware)


### PR DESCRIPTION
This PR exposes an `autoCompress` attribute so it can be set on the server and added an optional `customMiddleware` attribute to `serve` in order to be able to add a request interceptor for things like authentication, authorization, and CORS headers.

Also, fixed the `fullstack/backend` example for when running the `fullstack/frontend` Flutter Web example as it was failing due to lack of CORS support.