### PR TITLE
Move to element2 as element is deprecated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,16 +37,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_format; Dart 2.14.0; PKGS: dartfn, functions_framework, functions_framework_builder, integration_test; `dart analyze .`"
+    name: "analyze_format; Dart 2.14.0; PKGS: dartfn, functions_framework, integration_test; `dart analyze .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:dartfn-functions_framework-functions_framework_builder-integration_test;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:dartfn-functions_framework-integration_test;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:dartfn-functions_framework-functions_framework_builder-integration_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:dartfn-functions_framework-integration_test
             os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -72,15 +72,6 @@ jobs:
       - name: functions_framework; dart analyze .
         if: "always() && steps.functions_framework_pub_upgrade.conclusion == 'success'"
         working-directory: functions_framework
-        run: dart analyze .
-      - id: functions_framework_builder_pub_upgrade
-        name: functions_framework_builder; dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: functions_framework_builder
-        run: dart pub upgrade
-      - name: functions_framework_builder; dart analyze .
-        if: "always() && steps.functions_framework_builder_pub_upgrade.conclusion == 'success'"
-        working-directory: functions_framework_builder
         run: dart analyze .
       - id: integration_test_pub_upgrade
         name: integration_test; dart pub upgrade
@@ -124,6 +115,34 @@ jobs:
         working-directory: dartfn
         run: dart analyze --fatal-infos .
   job_004:
+    name: "analyze_format; Dart 2.17.0; PKG: functions_framework_builder; `dart analyze .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:functions_framework_builder;commands:analyze_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:functions_framework_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: functions_framework_builder_pub_upgrade
+        name: functions_framework_builder; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: functions_framework_builder
+        run: dart pub upgrade
+      - name: functions_framework_builder; dart analyze .
+        if: "always() && steps.functions_framework_builder_pub_upgrade.conclusion == 'success'"
+        working-directory: functions_framework_builder
+        run: dart analyze .
+  job_005:
     name: "analyze_format; Dart dev; PKG: dartfn; `dart analyze .`"
     runs-on: ubuntu-latest
     steps:
@@ -151,7 +170,7 @@ jobs:
         if: "always() && steps.dartfn_pub_upgrade.conclusion == 'success'"
         working-directory: dartfn
         run: dart analyze .
-  job_005:
+  job_006:
     name: "analyze_format; Dart dev; PKGS: dartfn, functions_framework, functions_framework_builder, integration_test; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -222,7 +241,7 @@ jobs:
         if: "always() && steps.integration_test_pub_upgrade.conclusion == 'success'"
         working-directory: integration_test
         run: dart analyze --fatal-infos .
-  job_006:
+  job_007:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -239,3 +258,4 @@ jobs:
       - job_003
       - job_004
       - job_005
+      - job_006

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -100,34 +100,6 @@ jobs:
         working-directory: dartfn
         run: dart test
   job_004:
-    name: "unit_test; Dart 2.14.0; PKG: functions_framework_builder; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:functions_framework_builder;commands:test_0"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:functions_framework_builder
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.14.0"
-      - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
-      - id: functions_framework_builder_pub_upgrade
-        name: functions_framework_builder; dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: functions_framework_builder
-        run: dart pub upgrade
-      - name: functions_framework_builder; dart test
-        if: "always() && steps.functions_framework_builder_pub_upgrade.conclusion == 'success'"
-        working-directory: functions_framework_builder
-        run: dart test
-  job_005:
     name: "unit_test; Dart 2.14.0; PKG: integration_test; `dart test -x presubmit-only`"
     runs-on: ubuntu-latest
     steps:
@@ -155,6 +127,34 @@ jobs:
         if: "always() && steps.integration_test_pub_upgrade.conclusion == 'success'"
         working-directory: integration_test
         run: dart test -x presubmit-only
+  job_005:
+    name: "unit_test; Dart 2.17.0; PKG: functions_framework_builder; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:functions_framework_builder;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:functions_framework_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: functions_framework_builder_pub_upgrade
+        name: functions_framework_builder; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: functions_framework_builder
+        run: dart pub upgrade
+      - name: functions_framework_builder; dart test
+        if: "always() && steps.functions_framework_builder_pub_upgrade.conclusion == 'success'"
+        working-directory: functions_framework_builder
+        run: dart test
   job_006:
     name: "unit_test; Dart dev; PKG: dartfn; `dart test --run-skipped -t presubmit-only`"
     runs-on: ubuntu-latest

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Tony Pujals <tonypujals@google.com>
 Grant Timmerman <timmerman@google.com>
 Andrew Lorenzen <alorenzen@google.com>
 Kevin Moore <kevmoo@google.com>
+Michael Thomsen <mit@google.com>

--- a/functions_framework_builder/CHANGELOG.md
+++ b/functions_framework_builder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0
+
+- Upgrade to `package:analyzer` 4.4.0 and later, where `element` has been
+  replaced with `element2`. As a result, Dart SDK 2.17 or later is now required.
+
 ## 0.4.6
 
 - Support the latest `package:analyzer`.

--- a/functions_framework_builder/lib/src/generic_function_type.dart
+++ b/functions_framework_builder/lib/src/generic_function_type.dart
@@ -100,12 +100,12 @@ class GenericFunctionType implements SupportedFunctionType {
 
     if (library.typeSystem.isSubtypeOf(element.type, functionType)) {
       if (paramInfo.paramType != null) {
-        if (library.exportNamespace.get(paramInfo.paramType!.element.name) ==
+        if (library.exportNamespace.get(paramInfo.paramType!.element2.name) ==
             null) {
           // TODO: add a test for this!
           throw InvalidGenerationSourceError(
-            'The type `${paramInfo.paramType!.element.name}` is not exposed by '
-            'the function library `${library.source.uri}` so it cannot '
+            'The type `${paramInfo.paramType!.element2.name}` is not exposed '
+            'by the function library `${library.source.uri}` so it cannot '
             'be used.',
           );
         }

--- a/functions_framework_builder/lib/src/valid_json_utils.dart
+++ b/functions_framework_builder/lib/src/valid_json_utils.dart
@@ -100,7 +100,7 @@ JsonReturnKind _validJsonReturnTypeCore(DartType type) {
   // Look for a `toJson` function that returns a JSON-able type
   if (type is InterfaceType) {
     final toJsonMethod =
-        type.element.lookUpMethod('toJson', type.element.library);
+        type.element2.lookUpMethod('toJson', type.element2.library);
     if (toJsonMethod != null &&
         toJsonMethod.parameters.every((element) => element.isOptional)) {
       type = toJsonMethod.returnType;

--- a/functions_framework_builder/mono_pkg.yaml
+++ b/functions_framework_builder/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # https://github.com/google/mono_repo.dart
 sdk:
-- 2.14.0
+- 2.17.0
 - dev
 
 stages:
@@ -11,6 +11,6 @@ stages:
     sdk: dev
   - group:
     - analyze: .
-    sdk: 2.14.0
+    sdk: 2.17.0
 - unit_test:
   - test

--- a/functions_framework_builder/pubspec.yaml
+++ b/functions_framework_builder/pubspec.yaml
@@ -1,20 +1,20 @@
 name: functions_framework_builder
-version: 0.4.6
+version: 0.5.0
 description: Builder for package:functions_framework
 repository: https://github.com/GoogleCloudPlatform/functions-framework-dart
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=2.7.0 <5.0.0'
+  analyzer: ">=4.4.0 <5.0.0"
   build: ^2.0.0
-  build_config: '>=0.4.3 <2.0.0'
+  build_config: ">=0.4.3 <2.0.0"
   collection: ^1.15.0
   dart_style: ^2.0.0
   # There is a tight version constraint because the builder has a strict
   # dependency on all features exposed.
-  functions_framework: '>=0.4.0 <0.4.2'
+  functions_framework: ">=0.4.0 <0.4.2"
   glob: ^2.0.0
   meta: ^1.2.4
   path: ^1.7.0


### PR DESCRIPTION
Fix failing CI:

```
Run dart analyze --fatal-infos .
Analyzing ....

   info - lib/src/generic_function_type.dart:103:62 - 'element' is deprecated and shouldn't be used. Use element2 instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
   info - lib/src/generic_function_type.dart:107:47 - 'element' is deprecated and shouldn't be used. Use element2 instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
   info - lib/src/valid_json_utils.dart:103:14 - 'element' is deprecated and shouldn't be used. Use element2 instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
   info - lib/src/valid_json_utils.dart:103:50 - 'element' is deprecated and shouldn't be used. Use element2 instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use

4 issues found.
```

https://github.com/GoogleCloudPlatform/functions-framework-dart/runs/7822753655?check_suite_focus=true
