### PR TITLE
fix: tie logging to the Zone, not the request

### DIFF
--- a/functions_framework/lib/src/request_context.dart
+++ b/functions_framework/lib/src/request_context.dart
@@ -34,7 +34,7 @@ class RequestContext {
 
   final responseHeaders = <String, /* String | List<String> */ Object>{};
 
-  RequestContext._(this.request) : logger = loggerForRequest(request);
+  RequestContext._(this.request) : logger = currentLogger;
 }
 
 @internal

--- a/functions_framework/lib/src/targets/http_targets.dart
+++ b/functions_framework/lib/src/targets/http_targets.dart
@@ -34,7 +34,7 @@ class HttpWithLoggerFunctionTarget extends FunctionTarget {
 
   @override
   FutureOr<Response> handler(Request request) =>
-      _function(request, loggerForRequest(request));
+      _function(request, currentLogger);
 
   HttpWithLoggerFunctionTarget(this._function);
 }

--- a/gcp/lib/gcp.dart
+++ b/gcp/lib/gcp.dart
@@ -28,6 +28,6 @@ export 'src/logging.dart'
         badRequestMiddleware,
         cloudLoggingMiddleware,
         createLoggingMiddleware,
-        loggerForRequest;
+        currentLogger;
 export 'src/serve.dart' show listenPort, serveHandler;
 export 'src/terminate.dart' show waitForTerminate;

--- a/integration_test/lib/functions.dart
+++ b/integration_test/lib/functions.dart
@@ -112,7 +112,7 @@ Future<Response> function(Request request) async {
 }
 
 @CloudFunction()
-Response loggingHandler(Request handler, RequestLogger logger) {
+Response loggingHandler(Request request, RequestLogger logger) {
   logger
     ..log('default', LogSeverity.defaultSeverity)
     ..debug('debug')


### PR DESCRIPTION
The previous model would have dropped the logger with calls to
Request.change because it was based on Expando
