### PR TITLE
fix(gcp): allow logging message as jsonPayload

### DIFF
--- a/gcp/CHANGELOG.md
+++ b/gcp/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Require Dart 3.0
 - Support `package:http` v1
 
+- fix: `cloudLoggingMiddleware` uses structured logs (`jsonPayload`) when message is of type `Map`. All other messages are logged as text (`textPayload`).
+
 ## 0.1.0
 
 - First release.

--- a/gcp/CHANGELOG.md
+++ b/gcp/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 - Require Dart 3.0
 - Support `package:http` v1
-
-- fix: `cloudLoggingMiddleware` uses structured logs (`jsonPayload`) when message is of type `Map`. All other messages are logged as text (`textPayload`).
+- `cloudLoggingMiddleware` uses structured logs (`jsonPayload`) when message is of type `Map`. All other messages are logged as text (`textPayload`).
 
 ## 0.1.0
 

--- a/gcp/CHANGELOG.md
+++ b/gcp/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.1.2-wip
+
+- `cloudLoggingMiddleware` uses structured logs (`jsonPayload`) when message is of type `Map`. All other messages are logged as text (`textPayload`).
+
 ## 0.1.1
 
 - Require Dart 3.0
 - Support `package:http` v1
-- `cloudLoggingMiddleware` uses structured logs (`jsonPayload`) when message is of type `Map`. All other messages are logged as text (`textPayload`).
 
 ## 0.1.0
 

--- a/gcp/lib/src/logging.dart
+++ b/gcp/lib/src/logging.dart
@@ -230,12 +230,12 @@ class _CloudLogger extends RequestLogger {
 
   @override
   void log(Object message, LogSeverity severity) =>
-      _zone.print(_createLogEntry(_traceId, '$message', severity));
+      _zone.print(_createLogEntry(_traceId, message, severity));
 }
 
 String _createLogEntry(
   String? traceValue,
-  String message,
+  Object message,
   LogSeverity severity, {
   Frame? stackFrame,
 }) {

--- a/gcp/lib/src/logging.dart
+++ b/gcp/lib/src/logging.dart
@@ -229,8 +229,13 @@ class _CloudLogger extends RequestLogger {
   _CloudLogger(this._zone, this._traceId);
 
   @override
-  void log(Object message, LogSeverity severity) =>
-      _zone.print(_createLogEntry(_traceId, message, severity));
+  void log(Object message, LogSeverity severity) => _zone.print(
+        _createLogEntry(
+          _traceId,
+          message is Map ? message : '$message',
+          severity,
+        ),
+      );
 }
 
 String _createLogEntry(

--- a/gcp/lib/src/logging.dart
+++ b/gcp/lib/src/logging.dart
@@ -98,6 +98,8 @@ final _loggerKey = Object();
 
 /// Return [Middleware] that logs errors using Google Cloud structured logs and
 /// returns the correct response.
+/// Log messages of type [Map] are logged as structured logs (`jsonPayload`).
+/// All other logs messages are logged as text logs (`textPayload`).
 Middleware cloudLoggingMiddleware(String projectId) {
   Handler hostedLoggingMiddleware(Handler innerHandler) => (request) async {
         // Add log correlation to nest all log messages beneath request log in

--- a/gcp/pubspec.yaml
+++ b/gcp/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gcp
 description: >-
   Utilities for running Dart code correctly on the Google Cloud Platform.
-version: 0.1.1
+version: 0.1.2-wip
 repository: https://github.com/GoogleCloudPlatform/functions-framework-dart/tree/main/gcp
 
 environment:


### PR DESCRIPTION
Closes #394 

Currently, log messages do not get interpreted as jsonPayload even if a JSON object is provided:

```dart
log({'hello': 'world'});
```

results in:

```
textPayload: "{hello: world}"
```

This change results in the following log:

```
jsonPayload: {
  message: {
    hello: world
  }
}
```

Are there existing tests for the logger? I looked but wasn't able to find any.